### PR TITLE
bugfix: improve detection of utimensat support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,16 @@ if(NOT HAVE_ATTR_XATTR_H)
     message(FATAL_ERROR "attr/xattr.h not found")
 endif()
 
+check_c_source_compiles ("
+  #include <unistd.h>
+  #include <sys/stat.h>
+  #include <fcntl.h>
+  int main() { utimensat(-1, NULL, NULL, 0); return 0; }
+  " HAS_UTIMENSAT)
+if(HAS_UTIMENSAT)
+    add_definitions (-DHAS_UTIMENSAT)
+endif()
+
 # set required definitions
 add_definitions (-D_FILE_OFFSET_BITS=64)
 

--- a/fuse_xattrs.c
+++ b/fuse_xattrs.c
@@ -149,7 +149,7 @@ static struct fuse_operations xmp_oper = {
         .chmod       = xmp_chmod,
         .chown       = xmp_chown,
         .truncate    = xmp_truncate,
-#ifdef HAVE_UTIMENSAT
+#ifdef HAS_UTIMENSAT
         .utimens     = xmp_utimens,
 #endif
         .open        = xmp_open,

--- a/passthrough.c
+++ b/passthrough.c
@@ -319,7 +319,7 @@ int xmp_truncate(const char *path, off_t size) {
     return 0;
 }
 
-#ifdef HAVE_UTIMENSAT
+#ifdef HAS_UTIMENSAT
 int xmp_utimens(const char *path, const struct timespec ts[2],
 struct fuse_file_info *fi)
 {


### PR DESCRIPTION
Seems like HAVE_UTIMENSAT cannot be dependent upon: on Arch linux,
the function is available, but the constant is nowhere to be found.

Closes #1